### PR TITLE
Improve error logging

### DIFF
--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -190,7 +190,7 @@ export class RPReporter implements Reporter {
 
         if (this.config.extendTestDescriptionWithLastError) {
           finishTestItemObj.description = (finishTestItemObj.description || '').concat(
-            `\n\`\`\`error\n${error.stack}\n\`\`\``,
+            `\n\`\`\`error\n${error.message}\n\`\`\``,
           );
         }
 
@@ -200,6 +200,15 @@ export class RPReporter implements Reporter {
           message: error.stack,
         };
         this.sendLog(testItemId, logRq);
+
+        if ('diff' in error) {
+          const logRqDiff: LogRQ = {
+            time: finishTestItemObj.endTime,
+            level: LOG_LEVELS.ERROR,
+            message: `\`\`\`diff\n${error.diff}\n\`\`\``,
+          };
+          this.sendLog(testItemId, logRqDiff);
+        }
       }
 
       const { promise } = this.client.finishTestItem(testItemId, finishTestItemObj);


### PR DESCRIPTION
- Uses `error.message` as description
- Append `error.diff` to logs if present

Fixes #24, if `error.diff` is present it will be added to the log entries.
It uses code block to avoid some characters being interpreted as syntax characters.
Example:
<img width="1403" height="246" alt="image" src="https://github.com/user-attachments/assets/f0f574c7-d6ca-4e84-a133-2bacbae95cc2" />


Also improves readability by using `error.message` as desription instead of `error.stack`.
In the screenshot behind, left is new and right current.
<img width="1756" height="602" alt="image" src="https://github.com/user-attachments/assets/eb8d0dd8-ee62-4302-9cd7-2899837dac85" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adds a dedicated diff log entry when a diff is available, using error-level severity and the test’s end time for clearer failure diagnostics.
  * When the option to extend test descriptions with the last error is enabled, the extended description now includes only the error message (not the full stack) to reduce noise.
  * The standard error log with the full stack trace is retained alongside the new diff entry for comprehensive debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->